### PR TITLE
Use type passed in to dictToObject to instantiate object

### DIFF
--- a/yacg/generators/templates/pythonBeans.mako
+++ b/yacg/generators/templates/pythonBeans.mako
@@ -84,7 +84,7 @@ class ${type.name}${ ' ({})'.format(pythonFuncs.getExtendsType(type, modelTypes,
     def dictToObject(cls, dict):
         if dict is None:
             return None
-        obj = ${type.name}()
+        obj = cls()
         % for property in type.properties:
             % if modelFuncs.isBaseType(property.type):
                 % if not property.isArray:


### PR DESCRIPTION
This enables the generated type to be subclassed yet still use dictToObject to create the desired type.