### PR TITLE
Fix parsing of `x-enumValues` properties on nested type definitions

### DIFF
--- a/yacg/builder/impl/dictionaryBuilder.py
+++ b/yacg/builder/impl/dictionaryBuilder.py
@@ -239,7 +239,7 @@ def _extractDefinitionsTypes(definitions, modelTypes, modelFileContainer, desire
         if enumEntry is not None:
             mainType = _extractEnumType(key, None, enumEntry, modelTypes, modelFileContainer)
             __initTags(mainType, modelFileContainer.parsedSchema)
-            __initEnumValues(mainType, modelFileContainer.parsedSchema)
+            __initEnumValues(mainType, object)
         else:
             type = _extractObjectType(
                 key, properties, additionalProperties, allOfEntry,


### PR DESCRIPTION
Bugfix: `modelFileContainer.parsedSchema` does not contain the `x-enumValues` properties when parsing referenced enum types in `definitions` part of the Schema.
This bug may also be present when parsing other properties of the schema (e.G. __initTags() function). I have no setup to test these features, so this PR only covers the `x-enumValues` property. 